### PR TITLE
fix MARS workflow issue when there is an empty result set inside

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-fsharplint": {
-      "version": "0.17.1",
+      "version": "0.21.2",
       "commands": [
         "dotnet-fsharplint"
       ]

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup .NET Environment
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 6.0.400
       - name: Restore .NET Tools
         run: dotnet tool restore --tool-manifest ./.config/dotnet-tools.json
       - name: Restore .NET Projects

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>

--- a/Vp.FSharp.Sql.Tests/SqlCommand for querySeqSync should.fs
+++ b/Vp.FSharp.Sql.Tests/SqlCommand for querySeqSync should.fs
@@ -230,6 +230,57 @@ let ``leave the connection open if initially not closed with access valueOrNone 
     PartialCallCounter.assertEqual callCounter 0 0
 
 [<Fact>]
+let ``when using a multiple result set and one or more is empty, get all values available`` () =
+    let callCounter = PartialCallCounter.initSame 0
+    let openCallback, closeCallback = PartialCallCounter.createCallbacks callCounter
+    let data = Mocks.fakeData
+                [
+                 [[1]];
+                 [];
+                 [[3;"toto"]]
+                ]
+                [
+                 [
+                    { Name = "id0"
+                      FieldType = typeof<int32>
+                      NativeTypeName = typeof<int32>.Name
+                    }
+                 ];
+                 [
+                    { Name = "id1"
+                      FieldType = typeof<int32>
+                      NativeTypeName = typeof<int32>.Name
+                    }
+                 ];
+                 [
+                    { Name = "id2"
+                      FieldType = typeof<int32>
+                      NativeTypeName = typeof<int32>.Name
+                    };
+                    { Name = "name"
+                      FieldType = typeof<String>
+                      NativeTypeName = typeof<String>.Name
+                    }
+                 ]
+                ]
+    use connection =
+        Mocks.Reader (Mocks.makeReader data)
+        |> Mocks.makeConnection "toto" ConnectionState.Connecting openCallback closeCallback
+    let deps = Mocks.makeDeps None
+    let conf = Mocks.makeConf None
+    let outcome =
+        SqlCommand.text "select 1"
+        |> SqlCommand.noLogger
+        |> SqlCommand.querySeqSync connection deps conf
+           (fun resultSetIndex rowIndex ->
+                let columns = if resultSetIndex = 1 then [] else [0]
+                readValueOrNoneByIndex columns resultSetIndex rowIndex)
+        |> Seq.fold (@) ([]: int32 option list)
+    outcome |> List.length =! 2
+    outcome =! [Some 1;Some 3]
+    PartialCallCounter.assertEqual callCounter 0 0
+
+[<Fact>]
 let ``log all events on globalLogger if connection initially closed with access valueOrNone by ordinal`` () =
     let callCounter = FullCallCounter.initSame 0
     let openCallback, closeCallback, loggerCallback = FullCallCounter.createCallbacks callCounter

--- a/Vp.FSharp.Sql.Tests/Vp.FSharp.Sql.Tests.fsproj
+++ b/Vp.FSharp.Sql.Tests/Vp.FSharp.Sql.Tests.fsproj
@@ -5,7 +5,6 @@
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Vp.FSharp.Sql.Tests/Vp.FSharp.Sql.Tests.fsproj
+++ b/Vp.FSharp.Sql.Tests/Vp.FSharp.Sql.Tests.fsproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <OutputType>Library</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
To fix the behaviour on a multiple result set workflow when there is one or more empty result set inside (not the first one).
Currently, as soon as the empty result set is reached, it stops the reading and we have a partial result.